### PR TITLE
bisq: Update to 1.10.1

### DIFF
--- a/network.bisq.Bisq.appdata.xml
+++ b/network.bisq.Bisq.appdata.xml
@@ -31,6 +31,7 @@
 
     <url type="homepage">https://bisq.network/</url>
     <releases>
+        <release version="1.10.1" date="2026-05-29"/>
         <release version="1.9.22" date="2025-12-23">
             <description></description>
         </release>

--- a/network.bisq.Bisq.yml
+++ b/network.bisq.Bisq.yml
@@ -33,8 +33,8 @@ modules:
       - install -D icon.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
     sources:
       - type: file
-        sha256: 19ba825d09b94925ff16fb92b06e5259bfeabc8b3df9afa2f74395a04a591fed
-        url: https://bisq.network/downloads/v1.10.0/Bisq-64bit-1.10.0.deb
+        sha256: 9de7fe82ac3695771ff54ef962cbc0da9b5dba06fb47e28a2437854a3732d2cc
+        url: https://bisq.network/downloads/v1.10.1/Bisq-64bit-1.10.1.deb
         dest-filename: Bisq.deb
         only-arches:
           - x86_64
@@ -47,7 +47,7 @@ modules:
       - type: file
         path: network.bisq.Bisq.desktop
       - type: file
-        url: https://github.com/bisq-network/bisq/raw/v1.9.22/Bisq1_icon.svg
+        url: https://github.com/bisq-network/bisq/raw/v1.10.1/Bisq1_icon.svg
         sha256: 6836845c01a1f1cc42117214c7c508eac9451b7e5c6d6dc40167d8a786b921ff
         dest-filename: icon.svg
         x-checker-data:


### PR DESCRIPTION
Full upgrade to v1.10.1, including updating metadata and URL to SVG.