### PR TITLE
Add release-url-template to enable automatic metadata updates

### DIFF
--- a/network.bisq.Bisq.yml
+++ b/network.bisq.Bisq.yml
@@ -55,4 +55,3 @@ modules:
           type: anitya
           project-id: 241531
           url-template: https://github.com/bisq-network/bisq/raw/v$version/Bisq1_icon.svg
-          release-url-template: https://github.com/bisq-network/bisq/releases/tag/v$version

--- a/network.bisq.Bisq.yml
+++ b/network.bisq.Bisq.yml
@@ -42,6 +42,7 @@ modules:
           type: anitya
           project-id: 241531
           url-template: https://bisq.network/downloads/v$version/Bisq-64bit-$version.deb
+          release-url-template: https://github.com/bisq-network/bisq/releases/tag/v$version
       - type: file
         path: network.bisq.Bisq.appdata.xml
       - type: file
@@ -54,3 +55,4 @@ modules:
           type: anitya
           project-id: 241531
           url-template: https://github.com/bisq-network/bisq/raw/v$version/Bisq1_icon.svg
+          release-url-template: https://github.com/bisq-network/bisq/releases/tag/v$version


### PR DESCRIPTION
This allows flatpak-external-data-checker to automatically update the appdata.xml metadata file with new release information when bot-generated PRs are created. The release-url-template points to the GitHub releases page for the bisq project, enabling proper version tracking in Flathub metadata.

Fixes #83